### PR TITLE
Fixes openactive/data-model-validator#102 - link to validator

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -42,8 +42,24 @@
           <%= availability_indicator(availability, dataset["data-url"]) %>
         </a>
       </td>
-      <td><%= yesno_indicator(dataset["uses-paging-spec"]) %></td>
-      <td><%= yesno_indicator(dataset["uses-opportunity-model"]) %></td>
+      <td>
+        <% if dataset["uses-paging-spec"] %>
+          <a href="https://validator.openactive.io/rpde?url=<%= ERB::Util.u(dataset["data-url"]) %>" target="_blank">
+            <%= yesno_indicator(dataset["uses-paging-spec"]) %>
+          </a>  
+        <% else %>
+          <%= yesno_indicator(dataset["uses-paging-spec"]) %>
+        <% end %>
+      </td>
+      <td>
+        <% if dataset["uses-opportunity-model"] %>
+          <a href="https://validator.openactive.io/?url=<%= ERB::Util.u(dataset["data-url"]) %>" target="_blank">
+            <%= yesno_indicator(dataset["uses-opportunity-model"]) %>
+          </a>  
+        <% else %>
+          <%= yesno_indicator(dataset["uses-opportunity-model"]) %>
+        <% end %>
+      </td>
       <td><%= yesno_indicator(dataset["has-coordinates"]) %></td>
       <td>
         <% if dataset["uses-paging-spec"] and dataset["uses-opportunity-model"] %>


### PR DESCRIPTION
Adds links to the validator if a feed is believed to implement RPDE or the modelling data spec