### PR TITLE
Updated directory list used to populate status page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.2
+FROM ruby:2.6.10
 
 RUN apt-get update && \
   apt-get install -y net-tools

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "2.4.2"
+ruby "2.6.10"
 
 gem 'sinatra', '~> 2.0.1'
 gem 'openactive', :git => "https://github.com/openactive/openactive.rb.git", :branch => "master"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A dashboard to support Openactive API users/publishers.
 If you have docker installed you can build and launch the API Dashboard with the `dockerize.sh` script. All you need to do is clone the repository and from the project directory run the following scripts:
 
 1. [Install docker](https://docs.docker.com/engine/installation/)
-2. `git clone https://github.com/howaskew/api-dashboard.git` Note - not the openactive repo
+2. `git clone https://github.com/openactive/api-dashboard.git` 
 3. `cd api-dashboard`
 4. `bundle install`
 5. `docker build -t openactive/dashboard .`

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -19,8 +19,8 @@ require_relative '../lib/dataset_parser'
 require_relative '../lib/dashboard_metrics'
 require_relative '../lib/local_geocoder/local_authority_geocoder'
 
-if ENV["REDISTOGO_URL"]
-  uri = URI.parse(ENV["REDISTOGO_URL"])
+if ENV["REDIS_URL"]
+  uri = URI.parse(ENV["REDIS_URL"])
   redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
 else
   oa_redis_host = ENV['OA_REDIS_HOST'] || '127.0.0.1'

--- a/directory.json
+++ b/directory.json
@@ -1,0 +1,2592 @@
+[
+    {
+        "title": "activeNewham Sessions and Facilities",
+        "dataset-site-url": "https://api.activenewham.org.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/activeNewham/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ActiveNewham-live-live-session-series",
+        "publisher-name": "activeNewham",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "activeNewham Sessions and Facilities",
+        "dataset-site-url": "https://api.activenewham.org.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/activeNewham/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ActiveNewham-live-live-scheduled-sessions",
+        "publisher-name": "activeNewham",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "activeNewham Sessions and Facilities",
+        "dataset-site-url": "https://api.activenewham.org.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/activeNewham/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ActiveNewham-live-live-facility-uses",
+        "publisher-name": "activeNewham",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "activeNewham Sessions and Facilities",
+        "dataset-site-url": "https://api.activenewham.org.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/activeNewham/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ActiveNewham-live-live-slots",
+        "publisher-name": "activeNewham",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "1Life Sessions and Facilities",
+        "dataset-site-url": "https://booking.1life.co.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/1Life/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/1Life-live-session-series",
+        "publisher-name": "1Life",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "1Life Sessions and Facilities",
+        "dataset-site-url": "https://booking.1life.co.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/1Life/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/1Life-live-scheduled-sessions",
+        "publisher-name": "1Life",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "1Life Sessions and Facilities",
+        "dataset-site-url": "https://booking.1life.co.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/1Life/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/1Life-live-facility-uses",
+        "publisher-name": "1Life",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "1Life Sessions and Facilities",
+        "dataset-site-url": "https://booking.1life.co.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/1Life/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/1Life-live-slots",
+        "publisher-name": "1Life",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Chelmsford City Sports Sessions and Facilities",
+        "dataset-site-url": "https://chelmsfordcitysports.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/chelmsfordcitysports/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Chelmsfordcitysports-live-session-series",
+        "publisher-name": "Chelmsford City Sports",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Chelmsford City Sports Sessions and Facilities",
+        "dataset-site-url": "https://chelmsfordcitysports.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/chelmsfordcitysports/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Chelmsfordcitysports-live-scheduled-sessions",
+        "publisher-name": "Chelmsford City Sports",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Chelmsford City Sports Sessions and Facilities",
+        "dataset-site-url": "https://chelmsfordcitysports.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/chelmsfordcitysports/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Chelmsfordcitysports-live-facility-uses",
+        "publisher-name": "Chelmsford City Sports",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Chelmsford City Sports Sessions and Facilities",
+        "dataset-site-url": "https://chelmsfordcitysports.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/chelmsfordcitysports/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Chelmsfordcitysports-live-slots",
+        "publisher-name": "Chelmsford City Sports",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Everyone Active Sessions and Facilities",
+        "dataset-site-url": "https://data.everyoneactive.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportsAndLeisureManagement/issues",
+        "feed-type": "CourseInstance",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/EveryoneActiveSLM-live-course-instance",
+        "publisher-name": "Everyone Active",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Everyone Active Sessions and Facilities",
+        "dataset-site-url": "https://data.everyoneactive.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportsAndLeisureManagement/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/EveryoneActiveSLM-live-session-series",
+        "publisher-name": "Everyone Active",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Everyone Active Sessions and Facilities",
+        "dataset-site-url": "https://data.everyoneactive.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportsAndLeisureManagement/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/EveryoneActiveSLM-live-scheduled-sessions",
+        "publisher-name": "Everyone Active",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Everyone Active Sessions and Facilities",
+        "dataset-site-url": "https://data.everyoneactive.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportsAndLeisureManagement/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/EveryoneActiveSLM-live-facility-uses",
+        "publisher-name": "Everyone Active",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Everyone Active Sessions and Facilities",
+        "dataset-site-url": "https://data.everyoneactive.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportsAndLeisureManagement/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/EveryoneActiveSLM-live-slots",
+        "publisher-name": "Everyone Active",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "LED Leisure Management Ltd Sessions and Facilities",
+        "dataset-site-url": "https://inside.ledleisure.co.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/LED/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/LED-live-session-series",
+        "publisher-name": "LED Leisure Management Ltd",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "LED Leisure Management Ltd Sessions and Facilities",
+        "dataset-site-url": "https://inside.ledleisure.co.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/LED/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/LED-live-scheduled-sessions",
+        "publisher-name": "LED Leisure Management Ltd",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "LED Leisure Management Ltd Sessions and Facilities",
+        "dataset-site-url": "https://inside.ledleisure.co.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/LED/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/LED-live-facility-uses",
+        "publisher-name": "LED Leisure Management Ltd",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "LED Leisure Management Ltd Sessions and Facilities",
+        "dataset-site-url": "https://inside.ledleisure.co.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/LED/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/LED-live-slots",
+        "publisher-name": "LED Leisure Management Ltd",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "LeisureSK Sessions and Facilities",
+        "dataset-site-url": "https://leisuresk.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/LeisureSK-live-session-series",
+        "publisher-name": "LeisureSK",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "LeisureSK Sessions and Facilities",
+        "dataset-site-url": "https://leisuresk.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/LeisureSK-live-scheduled-sessions",
+        "publisher-name": "LeisureSK",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "LeisureSK Sessions and Facilities",
+        "dataset-site-url": "https://leisuresk.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/LeisureSK-live-facility-uses",
+        "publisher-name": "LeisureSK",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "LeisureSK Sessions and Facilities",
+        "dataset-site-url": "https://leisuresk.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/LeisureSK-live-slots",
+        "publisher-name": "LeisureSK",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Leisure World Colchester Sessions and Facilities",
+        "dataset-site-url": "https://leisureworldmembership.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/ColchesterLeisureWorld/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ColchesterLeisureWorld-live-session-series",
+        "publisher-name": "Leisure World Colchester",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Leisure World Colchester Sessions and Facilities",
+        "dataset-site-url": "https://leisureworldmembership.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/ColchesterLeisureWorld/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ColchesterLeisureWorld-live-scheduled-sessions",
+        "publisher-name": "Leisure World Colchester",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Leisure World Colchester Sessions and Facilities",
+        "dataset-site-url": "https://leisureworldmembership.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/ColchesterLeisureWorld/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ColchesterLeisureWorld-live-facility-uses",
+        "publisher-name": "Leisure World Colchester",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Leisure World Colchester Sessions and Facilities",
+        "dataset-site-url": "https://leisureworldmembership.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/ColchesterLeisureWorld/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ColchesterLeisureWorld-live-slots",
+        "publisher-name": "Leisure World Colchester",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Magna Vitae Trust for Leisure and Culture Sessions and Facilities",
+        "dataset-site-url": "https://magnavitae.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Magna Vitae-live-session-series",
+        "publisher-name": "Magna Vitae Trust for Leisure and Culture",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Magna Vitae Trust for Leisure and Culture Sessions and Facilities",
+        "dataset-site-url": "https://magnavitae.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Magna Vitae-live-scheduled-sessions",
+        "publisher-name": "Magna Vitae Trust for Leisure and Culture",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Magna Vitae Trust for Leisure and Culture Sessions and Facilities",
+        "dataset-site-url": "https://magnavitae.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Magna Vitae-live-facility-uses",
+        "publisher-name": "Magna Vitae Trust for Leisure and Culture",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Magna Vitae Trust for Leisure and Culture Sessions and Facilities",
+        "dataset-site-url": "https://magnavitae.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Magna Vitae-live-slots",
+        "publisher-name": "Magna Vitae Trust for Leisure and Culture",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Active Northumberland Sessions and Facilities",
+        "dataset-site-url": "https://members.activenorthumberland.org.uk/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ActiveNorthumberland-live-session-series",
+        "publisher-name": "Active Northumberland",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Active Northumberland Sessions and Facilities",
+        "dataset-site-url": "https://members.activenorthumberland.org.uk/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ActiveNorthumberland-live-scheduled-sessions",
+        "publisher-name": "Active Northumberland",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Active Northumberland Sessions and Facilities",
+        "dataset-site-url": "https://members.activenorthumberland.org.uk/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ActiveNorthumberland-live-facility-uses",
+        "publisher-name": "Active Northumberland",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Active Northumberland Sessions and Facilities",
+        "dataset-site-url": "https://members.activenorthumberland.org.uk/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ActiveNorthumberland-live-slots",
+        "publisher-name": "Active Northumberland",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Nottingham City Council Sport and Leisure Sessions and Facilities",
+        "dataset-site-url": "https://ncc.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/NottinghamCC/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/NottinghamCC-live-session-series",
+        "publisher-name": "Nottingham City Council Sport and Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Nottingham City Council Sport and Leisure Sessions and Facilities",
+        "dataset-site-url": "https://ncc.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/NottinghamCC/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/NottinghamCC-live-scheduled-sessions",
+        "publisher-name": "Nottingham City Council Sport and Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Nottingham City Council Sport and Leisure Sessions and Facilities",
+        "dataset-site-url": "https://ncc.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/NottinghamCC/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/NottinghamCC-live-facility-uses",
+        "publisher-name": "Nottingham City Council Sport and Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Nottingham City Council Sport and Leisure Sessions and Facilities",
+        "dataset-site-url": "https://ncc.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/NottinghamCC/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/NottinghamCC-live-slots",
+        "publisher-name": "Nottingham City Council Sport and Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Brio Leisure Sessions and Facilities",
+        "dataset-site-url": "https://onlinebooking.brioleisure.org/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/BrioLeisure/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/BrioLeisure-live-session-series",
+        "publisher-name": "Brio Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Brio Leisure Sessions and Facilities",
+        "dataset-site-url": "https://onlinebooking.brioleisure.org/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/BrioLeisure/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/BrioLeisure-live-scheduled-sessions",
+        "publisher-name": "Brio Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Brio Leisure Sessions and Facilities",
+        "dataset-site-url": "https://onlinebooking.brioleisure.org/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/BrioLeisure/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/BrioLeisure-live-facility-uses",
+        "publisher-name": "Brio Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Brio Leisure Sessions and Facilities",
+        "dataset-site-url": "https://onlinebooking.brioleisure.org/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/BrioLeisure/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/BrioLeisure-live-slots",
+        "publisher-name": "Brio Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Fusion Lifestyle Sessions and Facilities",
+        "dataset-site-url": "https://opendata.fusion-lifestyle.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/FusionLifestyle/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/fusion-lifestyle-fl-live-session-series",
+        "publisher-name": "Fusion Lifestyle",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Fusion Lifestyle Sessions and Facilities",
+        "dataset-site-url": "https://opendata.fusion-lifestyle.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/FusionLifestyle/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/fusion-lifestyle-fl-live-scheduled-sessions",
+        "publisher-name": "Fusion Lifestyle",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Fusion Lifestyle Sessions and Facilities",
+        "dataset-site-url": "https://opendata.fusion-lifestyle.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/FusionLifestyle/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/fusion-lifestyle-fl-live-facility-uses",
+        "publisher-name": "Fusion Lifestyle",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Fusion Lifestyle Sessions and Facilities",
+        "dataset-site-url": "https://opendata.fusion-lifestyle.com/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/FusionLifestyle/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/fusion-lifestyle-fl-live-slots",
+        "publisher-name": "Fusion Lifestyle",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Fusion Lifestyle Training Sessions and Facilities",
+        "dataset-site-url": "https://opendata.fusion-lifestyle.com/OpenActiveTNG/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/fusion-lifestyle-fl-training-session-series",
+        "publisher-name": "Fusion Lifestyle Training",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Fusion Lifestyle Training Sessions and Facilities",
+        "dataset-site-url": "https://opendata.fusion-lifestyle.com/OpenActiveTNG/",
+        "discussion-url": "",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/fusion-lifestyle-fl-training-scheduled-sessions",
+        "publisher-name": "Fusion Lifestyle Training",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Fusion Lifestyle Training Sessions and Facilities",
+        "dataset-site-url": "https://opendata.fusion-lifestyle.com/OpenActiveTNG/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/fusion-lifestyle-fl-training-facility-uses",
+        "publisher-name": "Fusion Lifestyle Training",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Fusion Lifestyle Training Sessions and Facilities",
+        "dataset-site-url": "https://opendata.fusion-lifestyle.com/OpenActiveTNG/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/fusion-lifestyle-fl-training-slots",
+        "publisher-name": "Fusion Lifestyle Training",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Oxford University Sport Sessions and Facilities",
+        "dataset-site-url": "https://oxforduniversity.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Oxford-Univesity-live-session-series",
+        "publisher-name": "Oxford University Sport",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Oxford University Sport Sessions and Facilities",
+        "dataset-site-url": "https://oxforduniversity.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Oxford-Univesity-live-scheduled-sessions",
+        "publisher-name": "Oxford University Sport",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Oxford University Sport Sessions and Facilities",
+        "dataset-site-url": "https://oxforduniversity.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Oxford-Univesity-live-facility-uses",
+        "publisher-name": "Oxford University Sport",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Oxford University Sport Sessions and Facilities",
+        "dataset-site-url": "https://oxforduniversity.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Oxford-Univesity-live-slots",
+        "publisher-name": "Oxford University Sport",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Redbridge Sports Centre Sessions and Facilities",
+        "dataset-site-url": "https://rslonline.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/RedbridgeSportsCentre/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/RedbridgeSportsCentre-live-session-series",
+        "publisher-name": "Redbridge Sports Centre",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Redbridge Sports Centre Sessions and Facilities",
+        "dataset-site-url": "https://rslonline.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/RedbridgeSportsCentre/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/RedbridgeSportsCentre-live-scheduled-sessions",
+        "publisher-name": "Redbridge Sports Centre",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Redbridge Sports Centre Sessions and Facilities",
+        "dataset-site-url": "https://rslonline.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/RedbridgeSportsCentre/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/RedbridgeSportsCentre-live-facility-uses",
+        "publisher-name": "Redbridge Sports Centre",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Redbridge Sports Centre Sessions and Facilities",
+        "dataset-site-url": "https://rslonline.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/RedbridgeSportsCentre/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/RedbridgeSportsCentre-live-slots",
+        "publisher-name": "Redbridge Sports Centre",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Calderdale Sessions and Facilities",
+        "dataset-site-url": "https://sportcalderdale.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/Calderdale/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Calderdale-live-session-series",
+        "publisher-name": "Calderdale",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Calderdale Sessions and Facilities",
+        "dataset-site-url": "https://sportcalderdale.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/Calderdale/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Calderdale-live-scheduled-sessions",
+        "publisher-name": "Calderdale",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Calderdale Sessions and Facilities",
+        "dataset-site-url": "https://sportcalderdale.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/Calderdale/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Calderdale-live-facility-uses",
+        "publisher-name": "Calderdale",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Calderdale Sessions and Facilities",
+        "dataset-site-url": "https://sportcalderdale.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/Calderdale/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Calderdale-live-slots",
+        "publisher-name": "Calderdale",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "The Pulse Dursley Sessions and Facilities",
+        "dataset-site-url": "https://thepulse-dursley.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/ThePulseDursley/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ThePulse-live-session-series",
+        "publisher-name": "The Pulse Dursley",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "The Pulse Dursley Sessions and Facilities",
+        "dataset-site-url": "https://thepulse-dursley.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/ThePulseDursley/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ThePulse-live-scheduled-sessions",
+        "publisher-name": "The Pulse Dursley",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "The Pulse Dursley Sessions and Facilities",
+        "dataset-site-url": "https://thepulse-dursley.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/ThePulseDursley/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ThePulse-live-facility-uses",
+        "publisher-name": "The Pulse Dursley",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "The Pulse Dursley Sessions and Facilities",
+        "dataset-site-url": "https://thepulse-dursley.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/ThePulseDursley/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/ThePulse-live-slots",
+        "publisher-name": "The Pulse Dursley",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "TMActive Sessions and Facilities",
+        "dataset-site-url": "https://tmactive.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/TMActive/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/TMActive-live-session-series",
+        "publisher-name": "TMActive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "TMActive Sessions and Facilities",
+        "dataset-site-url": "https://tmactive.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/TMActive/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/TMActive-live-scheduled-sessions",
+        "publisher-name": "TMActive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "TMActive Sessions and Facilities",
+        "dataset-site-url": "https://tmactive.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/TMActive/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/TMActive-live-facility-uses",
+        "publisher-name": "TMActive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "TMActive Sessions and Facilities",
+        "dataset-site-url": "https://tmactive.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/TMActive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/TMActive-live-slots",
+        "publisher-name": "TMActive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Trafford Leisure Sessions and Facilities",
+        "dataset-site-url": "https://traffordleisure.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/TraffordLeisure-live-session-series",
+        "publisher-name": "Trafford Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Trafford Leisure Sessions and Facilities",
+        "dataset-site-url": "https://traffordleisure.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/TraffordLeisure-live-scheduled-sessions",
+        "publisher-name": "Trafford Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Trafford Leisure Sessions and Facilities",
+        "dataset-site-url": "https://traffordleisure.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/TraffordLeisure-live-facility-uses",
+        "publisher-name": "Trafford Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Trafford Leisure Sessions and Facilities",
+        "dataset-site-url": "https://traffordleisure.leisurecloud.net/OpenActive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/TraffordLeisure-live-slots",
+        "publisher-name": "Trafford Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Vision Redbridge Culture & Leisure Ltd Sessions and Facilities",
+        "dataset-site-url": "https://visionrcl.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/VisionRedbridge/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/VisionRedbridge-live-session-series",
+        "publisher-name": "Vision Redbridge Culture & Leisure Ltd",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Vision Redbridge Culture & Leisure Ltd Sessions and Facilities",
+        "dataset-site-url": "https://visionrcl.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/VisionRedbridge/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/VisionRedbridge-live-scheduled-sessions",
+        "publisher-name": "Vision Redbridge Culture & Leisure Ltd",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Vision Redbridge Culture & Leisure Ltd Sessions and Facilities",
+        "dataset-site-url": "https://visionrcl.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/VisionRedbridge/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/VisionRedbridge-live-facility-uses",
+        "publisher-name": "Vision Redbridge Culture & Leisure Ltd",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Vision Redbridge Culture & Leisure Ltd Sessions and Facilities",
+        "dataset-site-url": "https://visionrcl.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/VisionRedbridge/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/VisionRedbridge-live-slots",
+        "publisher-name": "Vision Redbridge Culture & Leisure Ltd",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Sport Blackpool Sessions and Facilities",
+        "dataset-site-url": "https://webbookings.blackpool.gov.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportBlackpool/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Blackpool-live-session-series",
+        "publisher-name": "Sport Blackpool",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Sport Blackpool Sessions and Facilities",
+        "dataset-site-url": "https://webbookings.blackpool.gov.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportBlackpool/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Blackpool-live-scheduled-sessions",
+        "publisher-name": "Sport Blackpool",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Sport Blackpool Sessions and Facilities",
+        "dataset-site-url": "https://webbookings.blackpool.gov.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportBlackpool/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Blackpool-live-facility-uses",
+        "publisher-name": "Sport Blackpool",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Sport Blackpool Sessions and Facilities",
+        "dataset-site-url": "https://webbookings.blackpool.gov.uk/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/SportBlackpool/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/Blackpool-live-slots",
+        "publisher-name": "Sport Blackpool",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "WVActive Sessions and Facilities",
+        "dataset-site-url": "https://wvactive.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/WVActive/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/WVActive-live-session-series",
+        "publisher-name": "WVActive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "WVActive Sessions and Facilities",
+        "dataset-site-url": "https://wvactive.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/WVActive/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/WVActive-live-scheduled-sessions",
+        "publisher-name": "WVActive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "WVActive Sessions and Facilities",
+        "dataset-site-url": "https://wvactive.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/WVActive/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/WVActive-live-facility-uses",
+        "publisher-name": "WVActive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "WVActive Sessions and Facilities",
+        "dataset-site-url": "https://wvactive.leisurecloud.net/OpenActive/",
+        "discussion-url": "https://github.com/gladstonemrm/WVActive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://opendata.leisurecloud.live/api/feeds/WVActive-live-slots",
+        "publisher-name": "WVActive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Halo Sessions and Facilities",
+        "dataset-site-url": "https://halo-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "SessionSeries",
+        "data-url": "https://halo-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "Halo",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Halo Sessions and Facilities",
+        "dataset-site-url": "https://halo-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "FacilityUse",
+        "data-url": "https://halo-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "Halo",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Halo Sessions and Facilities",
+        "dataset-site-url": "https://halo-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "Slot",
+        "data-url": "https://halo-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "Halo",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "BwD Leisure Sessions and Facilities",
+        "dataset-site-url": "https://blackburnwithdarwen-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "SessionSeries",
+        "data-url": "https://blackburnwithdarwen-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "BwD Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "BwD Leisure Sessions and Facilities",
+        "dataset-site-url": "https://blackburnwithdarwen-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "FacilityUse",
+        "data-url": "https://blackburnwithdarwen-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "BwD Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "BwD Leisure Sessions and Facilities",
+        "dataset-site-url": "https://blackburnwithdarwen-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "Slot",
+        "data-url": "https://blackburnwithdarwen-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "BwD Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Life Leisure Sessions and Facilities",
+        "dataset-site-url": "https://lifeleisure-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Life-Leisure",
+        "feed-type": "SessionSeries",
+        "data-url": "https://lifeleisure-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "Life Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Life Leisure Sessions and Facilities",
+        "dataset-site-url": "https://lifeleisure-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Life-Leisure",
+        "feed-type": "FacilityUse",
+        "data-url": "https://lifeleisure-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "Life Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Life Leisure Sessions and Facilities",
+        "dataset-site-url": "https://lifeleisure-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Life-Leisure",
+        "feed-type": "Slot",
+        "data-url": "https://lifeleisure-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "Life Leisure",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://gll-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://gll-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://gll-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://gll-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://gll-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://gll-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Serco Sessions and Facilities",
+        "dataset-site-url": "https://serco-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://serco-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "Serco",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Serco Sessions and Facilities",
+        "dataset-site-url": "https://serco-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://serco-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "Serco",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Serco Sessions and Facilities",
+        "dataset-site-url": "https://serco-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://serco-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "Serco",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://pentest-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://pentest-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://pentest-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://pentest-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://pentest-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://pentest-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Active Tameside Sessions and Facilities",
+        "dataset-site-url": "https://tameside-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Tameside-Leisure",
+        "feed-type": "SessionSeries",
+        "data-url": "https://tameside-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "Active Tameside",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Active Tameside Sessions and Facilities",
+        "dataset-site-url": "https://tameside-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Tameside-Leisure",
+        "feed-type": "FacilityUse",
+        "data-url": "https://tameside-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "Active Tameside",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Active Tameside Sessions and Facilities",
+        "dataset-site-url": "https://tameside-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Tameside-Leisure",
+        "feed-type": "Slot",
+        "data-url": "https://tameside-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "Active Tameside",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://lancaster-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "SessionSeries",
+        "data-url": "https://lancaster-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://lancaster-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "FacilityUse",
+        "data-url": "https://lancaster-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://lancaster-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "",
+        "feed-type": "Slot",
+        "data-url": "https://lancaster-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Jubilee Hall Trust Sessions and Facilities",
+        "dataset-site-url": "https://jubileehall-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Jubilee-Hall",
+        "feed-type": "SessionSeries",
+        "data-url": "https://jubileehall-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "Jubilee Hall Trust",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Jubilee Hall Trust Sessions and Facilities",
+        "dataset-site-url": "https://jubileehall-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Jubilee-Hall",
+        "feed-type": "FacilityUse",
+        "data-url": "https://jubileehall-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "Jubilee Hall Trust",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Jubilee Hall Trust Sessions and Facilities",
+        "dataset-site-url": "https://jubileehall-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Jubilee-Hall",
+        "feed-type": "Slot",
+        "data-url": "https://jubileehall-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "Jubilee Hall Trust",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Parkwood Leisure Ltd, its subsidiaries and partner organisations Sessions and Facilities",
+        "dataset-site-url": "https://leisurecentre-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Parkwood-Leisure",
+        "feed-type": "SessionSeries",
+        "data-url": "https://leisurecentre-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "Parkwood Leisure Ltd, its subsidiaries and partner organisations",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Parkwood Leisure Ltd, its subsidiaries and partner organisations Sessions and Facilities",
+        "dataset-site-url": "https://leisurecentre-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Parkwood-Leisure",
+        "feed-type": "FacilityUse",
+        "data-url": "https://leisurecentre-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "Parkwood Leisure Ltd, its subsidiaries and partner organisations",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Parkwood Leisure Ltd, its subsidiaries and partner organisations Sessions and Facilities",
+        "dataset-site-url": "https://leisurecentre-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Parkwood-Leisure",
+        "feed-type": "Slot",
+        "data-url": "https://leisurecentre-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "Parkwood Leisure Ltd, its subsidiaries and partner organisations",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Lincs Inspire Sessions and Facilities",
+        "dataset-site-url": "https://lincsinspire-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Lincs-Inspire",
+        "feed-type": "SessionSeries",
+        "data-url": "https://lincsinspire-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "Lincs Inspire",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Lincs Inspire Sessions and Facilities",
+        "dataset-site-url": "https://lincsinspire-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Lincs-Inspire",
+        "feed-type": "FacilityUse",
+        "data-url": "https://lincsinspire-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "Lincs Inspire",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Lincs Inspire Sessions and Facilities",
+        "dataset-site-url": "https://lincsinspire-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Lincs-Inspire",
+        "feed-type": "Slot",
+        "data-url": "https://lincsinspire-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "Lincs Inspire",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "SLL and InspireAll Sessions and Facilities",
+        "dataset-site-url": "https://sllandinspireall-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Stevenage-Leisure",
+        "feed-type": "SessionSeries",
+        "data-url": "https://sllandinspireall-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "SLL and InspireAll",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "SLL and InspireAll Sessions and Facilities",
+        "dataset-site-url": "https://sllandinspireall-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Stevenage-Leisure",
+        "feed-type": "FacilityUse",
+        "data-url": "https://sllandinspireall-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "SLL and InspireAll",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "SLL and InspireAll Sessions and Facilities",
+        "dataset-site-url": "https://sllandinspireall-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Stevenage-Leisure",
+        "feed-type": "Slot",
+        "data-url": "https://sllandinspireall-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "SLL and InspireAll",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "ANGUSalive Sessions and Facilities",
+        "dataset-site-url": "https://angusalive-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "SessionSeries",
+        "data-url": "https://angusalive-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "ANGUSalive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "ANGUSalive Sessions and Facilities",
+        "dataset-site-url": "https://angusalive-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "FacilityUse",
+        "data-url": "https://angusalive-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "ANGUSalive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "ANGUSalive Sessions and Facilities",
+        "dataset-site-url": "https://angusalive-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware",
+        "feed-type": "Slot",
+        "data-url": "https://angusalive-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "ANGUSalive",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://derbyactive-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Derby-Active",
+        "feed-type": "SessionSeries",
+        "data-url": "https://derbyactive-openactive.legendonlineservices.co.uk/api/sessions",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://derbyactive-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Derby-Active",
+        "feed-type": "FacilityUse",
+        "data-url": "https://derbyactive-openactive.legendonlineservices.co.uk/api/facility-uses",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": " Sessions and Facilities",
+        "dataset-site-url": "https://derbyactive-openactive.legendonlineservices.co.uk/openactive/",
+        "discussion-url": "https://github.com/Legendware/Derby-Active",
+        "feed-type": "Slot",
+        "data-url": "https://derbyactive-openactive.legendonlineservices.co.uk/api/facility-uses/events",
+        "publisher-name": "",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bookwhen Courses, Sessions, and Events",
+        "dataset-site-url": "https://data.bookwhen.com/",
+        "discussion-url": "https://github.com/bookwhen/opendata/issues",
+        "feed-type": "CourseInstance",
+        "data-url": "https://bookwhen.com/api/openactive/courseinstances",
+        "publisher-name": "Bookwhen",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bookwhen Courses, Sessions, and Events",
+        "dataset-site-url": "https://data.bookwhen.com/",
+        "discussion-url": "https://github.com/bookwhen/opendata/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://bookwhen.com/api/openactive/scheduledsessions",
+        "publisher-name": "Bookwhen",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bookwhen Courses, Sessions, and Events",
+        "dataset-site-url": "https://data.bookwhen.com/",
+        "discussion-url": "https://github.com/bookwhen/opendata/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://bookwhen.com/api/openactive/sessionseries",
+        "publisher-name": "Bookwhen",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bookwhen Courses, Sessions, and Events",
+        "dataset-site-url": "https://data.bookwhen.com/",
+        "discussion-url": "https://github.com/bookwhen/opendata/issues",
+        "feed-type": "Event",
+        "data-url": "https://bookwhen.com/api/openactive/events",
+        "publisher-name": "Bookwhen",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Open Sessions Sessions and Events",
+        "dataset-site-url": "https://opensessions.io/openactive/",
+        "discussion-url": "https://github.com/opensessions/opendata/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opensessions.io/api/rpde/session-series",
+        "publisher-name": "Open Sessions",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Open Sessions Sessions and Events",
+        "dataset-site-url": "https://opensessions.io/openactive/",
+        "discussion-url": "https://github.com/opensessions/opendata/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://opensessions.io/api/rpde/scheduled-sessions",
+        "publisher-name": "Open Sessions",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Open Sessions Sessions and Events",
+        "dataset-site-url": "https://opensessions.io/openactive/",
+        "discussion-url": "https://github.com/opensessions/opendata/issues",
+        "feed-type": "Event",
+        "data-url": "https://opensessions.io/api/rpde/events",
+        "publisher-name": "Open Sessions",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Playwaze Sessions, Events, On Demand Events and Facilities",
+        "dataset-site-url": "https://playwaze.com/opendata/openactive",
+        "discussion-url": "https://github.com/Playwaze/opendata/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://playwaze.com/feeds/scheduled-sessions",
+        "publisher-name": "Playwaze",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Playwaze Sessions, Events, On Demand Events and Facilities",
+        "dataset-site-url": "https://playwaze.com/opendata/openactive",
+        "discussion-url": "https://github.com/Playwaze/opendata/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://playwaze.com/feeds/session-series",
+        "publisher-name": "Playwaze",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Playwaze Sessions, Events, On Demand Events and Facilities",
+        "dataset-site-url": "https://playwaze.com/opendata/openactive",
+        "discussion-url": "https://github.com/Playwaze/opendata/issues",
+        "feed-type": "Event",
+        "data-url": "https://playwaze.com/feeds/events",
+        "publisher-name": "Playwaze",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Playwaze Sessions, Events, On Demand Events and Facilities",
+        "dataset-site-url": "https://playwaze.com/opendata/openactive",
+        "discussion-url": "https://github.com/Playwaze/opendata/issues",
+        "feed-type": "OnDemandEvent",
+        "data-url": "https://playwaze.com/feeds/on-demand-event",
+        "publisher-name": "Playwaze",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Playwaze Sessions, Events, On Demand Events and Facilities",
+        "dataset-site-url": "https://playwaze.com/opendata/openactive",
+        "discussion-url": "https://github.com/Playwaze/opendata/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://playwaze.com/feeds/facility-uses",
+        "publisher-name": "Playwaze",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Exercise Anywhere Activities and Events",
+        "dataset-site-url": "https://opendata.exercise-anywhere.com/",
+        "discussion-url": "https://github.com/exercise-anywhere/opendata/issues",
+        "feed-type": "Event",
+        "data-url": "https://opendata.exercise-anywhere.com/api/rpde/events",
+        "publisher-name": "Exercise Anywhere",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Exercise Anywhere Activities and Events",
+        "dataset-site-url": "https://opendata.exercise-anywhere.com/",
+        "discussion-url": "https://github.com/exercise-anywhere/opendata/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://opendata.exercise-anywhere.com/api/rpde/session-series",
+        "publisher-name": "Exercise Anywhere",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Exercise Anywhere Activities and Events",
+        "dataset-site-url": "https://opendata.exercise-anywhere.com/",
+        "discussion-url": "https://github.com/exercise-anywhere/opendata/issues",
+        "feed-type": "ScheduledSessions",
+        "data-url": "https://opendata.exercise-anywhere.com/api/rpde/scheduled-sessions",
+        "publisher-name": "Exercise Anywhere",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Participant",
+        "dataset-site-url": "https://www.participant.co.uk",
+        "discussion-url": "https://github.com/participant-co-uk/OpenActive/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "http://legacyapi.deltager.no/api/v1/oa/1325/sessions",
+        "publisher-name": "Participant.co.uk",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Participant",
+        "dataset-site-url": "https://www.participant.co.uk",
+        "discussion-url": "https://github.com/participant-co-uk/OpenActive/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "http://legacyapi.deltager.no/api/v1/oa/1325/scheduled-sessions",
+        "publisher-name": "Participant.co.uk",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Participant",
+        "dataset-site-url": "https://www.participant.co.uk",
+        "discussion-url": "https://github.com/participant-co-uk/OpenActive/issues",
+        "feed-type": "Event",
+        "data-url": "http://legacyapi.deltager.no/api/v1/oa/1325/events",
+        "publisher-name": "Participant.co.uk",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Participant",
+        "dataset-site-url": "https://www.participant.co.uk",
+        "discussion-url": "https://github.com/participant-co-uk/OpenActive/issues",
+        "feed-type": "Course",
+        "data-url": "http://legacyapi.deltager.no/api/v1/oa/1325/courses",
+        "publisher-name": "Participant.co.uk",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "TeamUp Sessions and Events",
+        "dataset-site-url": "https://goteamup.com/api/openactive/v1/",
+        "discussion-url": "https://github.com/goteamup/opendata/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://goteamup.com/api/openactive/v1/sessionseries",
+        "publisher-name": "TeamUp",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "TeamUp Sessions and Events",
+        "dataset-site-url": "https://goteamup.com/api/openactive/v1/",
+        "discussion-url": "https://github.com/goteamup/opendata/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://goteamup.com/api/openactive/v1/scheduledsessions",
+        "publisher-name": "TeamUp",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "TeamUp Sessions and Events",
+        "dataset-site-url": "https://goteamup.com/api/openactive/v1/",
+        "discussion-url": "https://github.com/goteamup/opendata/issues",
+        "feed-type": "Event",
+        "data-url": "https://goteamup.com/api/openactive/v1/events",
+        "publisher-name": "TeamUp",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Played Sessions and Facilities",
+        "dataset-site-url": "https://openactive.played.co/openactive/",
+        "discussion-url": "https://github.com/openactive/OpenActive.Server.NET/issues",
+        "feed-type": "ScheduledSession",
+        "data-url": "https://openactive.played.co/feeds/scheduled-sessions",
+        "publisher-name": "Played",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Played Sessions and Facilities",
+        "dataset-site-url": "https://openactive.played.co/openactive/",
+        "discussion-url": "https://github.com/openactive/OpenActive.Server.NET/issues",
+        "feed-type": "SessionSeries",
+        "data-url": "https://openactive.played.co/feeds/session-series",
+        "publisher-name": "Played",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Played Sessions and Facilities",
+        "dataset-site-url": "https://openactive.played.co/openactive/",
+        "discussion-url": "https://github.com/openactive/OpenActive.Server.NET/issues",
+        "feed-type": "FacilityUse",
+        "data-url": "https://openactive.played.co/feeds/facility-uses",
+        "publisher-name": "Played",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Played Sessions and Facilities",
+        "dataset-site-url": "https://openactive.played.co/openactive/",
+        "discussion-url": "https://github.com/openactive/OpenActive.Server.NET/issues",
+        "feed-type": "Slot for FacilityUse",
+        "data-url": "https://openactive.played.co/feeds/facility-use-slots",
+        "publisher-name": "Played",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Feel Good Too (formerly Ive Farm Fields) Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/0fe56016-a25d-4cfa-9030-c969205790fa/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/0fe56016-a25d-4cfa-9030-c969205790fa/individual-facility-uses",
+        "publisher-name": "Feel Good Too (formerly Ive Farm Fields)",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Feel Good Too (formerly Ive Farm Fields) Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/0fe56016-a25d-4cfa-9030-c969205790fa/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/0fe56016-a25d-4cfa-9030-c969205790fa/slots",
+        "publisher-name": "Feel Good Too (formerly Ive Farm Fields)",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Ainslie Wood Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/116e6734-ae5f-4997-b67d-1370896c323c/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/116e6734-ae5f-4997-b67d-1370896c323c/individual-facility-uses",
+        "publisher-name": "Ainslie Wood Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Ainslie Wood Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/116e6734-ae5f-4997-b67d-1370896c323c/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/116e6734-ae5f-4997-b67d-1370896c323c/slots",
+        "publisher-name": "Ainslie Wood Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Drapers Field Facilities,https://walthamforestcouncil.bookteq.com/api/open-active/3193de23-55e5-40da-a172-868920c65351/,https://github.com/playfinder/openactive/issues,IndividualFacilityUse,https://walthamforestcouncil.bookteq.com/api/open-active/3193de23-55e5-40da-a172-868920c65351/individual-facility-uses,Drapers Field",
+        "dataset-site-url": "https://creativecommons.org/licenses/by/4.0/",
+        "discussion-url": "true",
+        "feed-type": "",
+        "data-url": "",
+        "publisher-name": "",
+        "license-url": "",
+        "publish": ""
+    },
+    {
+        "title": "Drapers Field Facilities,https://walthamforestcouncil.bookteq.com/api/open-active/3193de23-55e5-40da-a172-868920c65351/,https://github.com/playfinder/openactive/issues,Slot,https://walthamforestcouncil.bookteq.com/api/open-active/3193de23-55e5-40da-a172-868920c65351/slots,Drapers Field",
+        "dataset-site-url": "https://creativecommons.org/licenses/by/4.0/",
+        "discussion-url": "true",
+        "feed-type": "",
+        "data-url": "",
+        "publisher-name": "",
+        "license-url": "",
+        "publish": ""
+    },
+    {
+        "title": "Britannia Playing Fields Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/3e48b8b4-79d2-4543-9643-6818bc557623/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/3e48b8b4-79d2-4543-9643-6818bc557623/individual-facility-uses",
+        "publisher-name": "Britannia Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Britannia Playing Fields Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/3e48b8b4-79d2-4543-9643-6818bc557623/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/3e48b8b4-79d2-4543-9643-6818bc557623/slots",
+        "publisher-name": "Britannia Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Jubilee Sports Ground, Highams Park Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/41c6a4e5-8ba6-46e3-910a-f2915afb3149/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/41c6a4e5-8ba6-46e3-910a-f2915afb3149/individual-facility-uses",
+        "publisher-name": "Jubilee Sports Ground, Highams Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Jubilee Sports Ground, Highams Park Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/41c6a4e5-8ba6-46e3-910a-f2915afb3149/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/41c6a4e5-8ba6-46e3-910a-f2915afb3149/slots",
+        "publisher-name": "Jubilee Sports Ground, Highams Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Salisbury Hall Playing Fields Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/6924be1e-ddb3-4f54-9caf-42be5ec4b2ad/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/6924be1e-ddb3-4f54-9caf-42be5ec4b2ad/individual-facility-uses",
+        "publisher-name": "Salisbury Hall Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Salisbury Hall Playing Fields Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/6924be1e-ddb3-4f54-9caf-42be5ec4b2ad/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/6924be1e-ddb3-4f54-9caf-42be5ec4b2ad/slots",
+        "publisher-name": "Salisbury Hall Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Parmiters Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/8f6252c4-2beb-4de5-998e-c4dc049afbc4/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/8f6252c4-2beb-4de5-998e-c4dc049afbc4/individual-facility-uses",
+        "publisher-name": "Parmiters Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Parmiters Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/8f6252c4-2beb-4de5-998e-c4dc049afbc4/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/8f6252c4-2beb-4de5-998e-c4dc049afbc4/slots",
+        "publisher-name": "Parmiters Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Cavendish Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/9dffaac1-8909-448f-a8dd-549aedee8574/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/9dffaac1-8909-448f-a8dd-549aedee8574/individual-facility-uses",
+        "publisher-name": "Cavendish Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Cavendish Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/9dffaac1-8909-448f-a8dd-549aedee8574/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/9dffaac1-8909-448f-a8dd-549aedee8574/slots",
+        "publisher-name": "Cavendish Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Leyton Jubilee Park Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/e317a6c2-2089-4991-8f35-e9937fc1f7fa/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/e317a6c2-2089-4991-8f35-e9937fc1f7fa/individual-facility-uses",
+        "publisher-name": "Leyton Jubilee Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Leyton Jubilee Park Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/e317a6c2-2089-4991-8f35-e9937fc1f7fa/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/e317a6c2-2089-4991-8f35-e9937fc1f7fa/slots",
+        "publisher-name": "Leyton Jubilee Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Rolls Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/ec7ce4a7-bd89-475a-9f2e-e46d5c08886b/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/ec7ce4a7-bd89-475a-9f2e-e46d5c08886b/individual-facility-uses",
+        "publisher-name": "Rolls Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Rolls Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/ec7ce4a7-bd89-475a-9f2e-e46d5c08886b/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/ec7ce4a7-bd89-475a-9f2e-e46d5c08886b/slots",
+        "publisher-name": "Rolls Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Low Hall Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/f8095434-19d3-48e7-bdc0-ae529e9e8da2/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/f8095434-19d3-48e7-bdc0-ae529e9e8da2/individual-facility-uses",
+        "publisher-name": "Low Hall Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Low Hall Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/f8095434-19d3-48e7-bdc0-ae529e9e8da2/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/f8095434-19d3-48e7-bdc0-ae529e9e8da2/slots",
+        "publisher-name": "Low Hall Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Leyton Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/94df961d-f35e-45d7-a0fe-636779153001/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/94df961d-f35e-45d7-a0fe-636779153001/individual-facility-uses",
+        "publisher-name": "Leyton Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Leyton Sports Ground Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/94df961d-f35e-45d7-a0fe-636779153001/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/94df961d-f35e-45d7-a0fe-636779153001/slots",
+        "publisher-name": "Leyton Sports Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Wixams Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/17515964-f226-4d39-861c-5a59b0a269bc/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/17515964-f226-4d39-861c-5a59b0a269bc/individual-facility-uses",
+        "publisher-name": "Wixams",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Wixams Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/17515964-f226-4d39-861c-5a59b0a269bc/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/17515964-f226-4d39-861c-5a59b0a269bc/slots",
+        "publisher-name": "Wixams",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Mowsbury Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/1c3194b7-0b79-4ade-b4f0-eb5af0076793/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/1c3194b7-0b79-4ade-b4f0-eb5af0076793/individual-facility-uses",
+        "publisher-name": "Mowsbury Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Mowsbury Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/1c3194b7-0b79-4ade-b4f0-eb5af0076793/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/1c3194b7-0b79-4ade-b4f0-eb5af0076793/slots",
+        "publisher-name": "Mowsbury Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Russell Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/4040fc19-d1b0-41bb-8955-4dc4a95f883f/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/4040fc19-d1b0-41bb-8955-4dc4a95f883f/individual-facility-uses",
+        "publisher-name": "Russell Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Russell Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/4040fc19-d1b0-41bb-8955-4dc4a95f883f/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/4040fc19-d1b0-41bb-8955-4dc4a95f883f/slots",
+        "publisher-name": "Russell Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Addison Howard Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/48b9d522-c7ef-47e0-a498-ce68bc49447c/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/48b9d522-c7ef-47e0-a498-ce68bc49447c/individual-facility-uses",
+        "publisher-name": "Addison Howard Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Addison Howard Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/48b9d522-c7ef-47e0-a498-ce68bc49447c/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/48b9d522-c7ef-47e0-a498-ce68bc49447c/slots",
+        "publisher-name": "Addison Howard Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Hillgrounds Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/50696a62-73ee-4f8b-9c01-1dc8b9026ce2/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/50696a62-73ee-4f8b-9c01-1dc8b9026ce2/individual-facility-uses",
+        "publisher-name": "Hillgrounds",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Hillgrounds Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/50696a62-73ee-4f8b-9c01-1dc8b9026ce2/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/50696a62-73ee-4f8b-9c01-1dc8b9026ce2/slots",
+        "publisher-name": "Hillgrounds",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Allen Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/82c221ea-2ea0-4692-bd4f-e8fc652d2e36/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/82c221ea-2ea0-4692-bd4f-e8fc652d2e36/individual-facility-uses",
+        "publisher-name": "Allen Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Allen Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/82c221ea-2ea0-4692-bd4f-e8fc652d2e36/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/82c221ea-2ea0-4692-bd4f-e8fc652d2e36/slots",
+        "publisher-name": "Allen Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bedford Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/946b63ca-4468-4b56-a9b0-16708c776968/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/946b63ca-4468-4b56-a9b0-16708c776968/individual-facility-uses",
+        "publisher-name": "Bedford Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bedford Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/946b63ca-4468-4b56-a9b0-16708c776968/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/946b63ca-4468-4b56-a9b0-16708c776968/slots",
+        "publisher-name": "Bedford Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Moor Lane Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/9992a3a8-86b4-42e1-8468-9cefe8f1e284/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/9992a3a8-86b4-42e1-8468-9cefe8f1e284/individual-facility-uses",
+        "publisher-name": "Moor Lane",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Moor Lane Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/9992a3a8-86b4-42e1-8468-9cefe8f1e284/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/9992a3a8-86b4-42e1-8468-9cefe8f1e284/slots",
+        "publisher-name": "Moor Lane",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Woodlands Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/bf3f9161-c06d-4362-ada3-a7987c37f06f/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/bf3f9161-c06d-4362-ada3-a7987c37f06f/individual-facility-uses",
+        "publisher-name": "Woodlands Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Woodlands Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/bf3f9161-c06d-4362-ada3-a7987c37f06f/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/bf3f9161-c06d-4362-ada3-a7987c37f06f/slots",
+        "publisher-name": "Woodlands Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Rectory Park Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/3fea7124-d13e-4ce5-8032-d989fbbf671e/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/3fea7124-d13e-4ce5-8032-d989fbbf671e/individual-facility-uses",
+        "publisher-name": "Rectory Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Rectory Park Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/3fea7124-d13e-4ce5-8032-d989fbbf671e/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/3fea7124-d13e-4ce5-8032-d989fbbf671e/slots",
+        "publisher-name": "Rectory Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Perivale Park Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/614ce266-e603-487b-ac55-2c5bc7be2df1/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/614ce266-e603-487b-ac55-2c5bc7be2df1/individual-facility-uses",
+        "publisher-name": "Perivale Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Perivale Park Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/614ce266-e603-487b-ac55-2c5bc7be2df1/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/614ce266-e603-487b-ac55-2c5bc7be2df1/slots",
+        "publisher-name": "Perivale Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Elthorne Waterside Pitches Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/92c8385b-a099-4186-ad9e-07fce9fe9e23/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/92c8385b-a099-4186-ad9e-07fce9fe9e23/individual-facility-uses",
+        "publisher-name": "Elthorne Waterside Pitches",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Elthorne Waterside Pitches Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/92c8385b-a099-4186-ad9e-07fce9fe9e23/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/92c8385b-a099-4186-ad9e-07fce9fe9e23/slots",
+        "publisher-name": "Elthorne Waterside Pitches",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Islip Manor Park  Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/9e120fd7-9371-4b1f-b0a0-363b98d42e2b/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/9e120fd7-9371-4b1f-b0a0-363b98d42e2b/individual-facility-uses",
+        "publisher-name": "Islip Manor Park ",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Islip Manor Park  Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/9e120fd7-9371-4b1f-b0a0-363b98d42e2b/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/9e120fd7-9371-4b1f-b0a0-363b98d42e2b/slots",
+        "publisher-name": "Islip Manor Park ",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Dormers Wells LC Pitches Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/c410bf26-e7e7-47c2-8382-b70491aaeeac/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/c410bf26-e7e7-47c2-8382-b70491aaeeac/individual-facility-uses",
+        "publisher-name": "Dormers Wells LC Pitches",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Dormers Wells LC Pitches Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/c410bf26-e7e7-47c2-8382-b70491aaeeac/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/c410bf26-e7e7-47c2-8382-b70491aaeeac/slots",
+        "publisher-name": "Dormers Wells LC Pitches",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Southfield Road Playing Fields Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/d12099f5-8ea9-48dc-83ce-7d46e6811380/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/d12099f5-8ea9-48dc-83ce-7d46e6811380/individual-facility-uses",
+        "publisher-name": "Southfield Road Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Southfield Road Playing Fields Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/d12099f5-8ea9-48dc-83ce-7d46e6811380/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/d12099f5-8ea9-48dc-83ce-7d46e6811380/slots",
+        "publisher-name": "Southfield Road Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "North Acton Playing Fields Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/e96f1373-fcaa-4c82-bbdf-6a2b1379f8b0/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/e96f1373-fcaa-4c82-bbdf-6a2b1379f8b0/individual-facility-uses",
+        "publisher-name": "North Acton Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "North Acton Playing Fields Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/e96f1373-fcaa-4c82-bbdf-6a2b1379f8b0/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/e96f1373-fcaa-4c82-bbdf-6a2b1379f8b0/slots",
+        "publisher-name": "North Acton Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Cornwallis Adventure Playground Facilities",
+        "dataset-site-url": "https://awesomecic.bookteq.com/api/open-active/b4063b7b-1022-4c76-a88d-8add6eb20529/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://awesomecic.bookteq.com/api/open-active/b4063b7b-1022-4c76-a88d-8add6eb20529/individual-facility-uses",
+        "publisher-name": "Cornwallis Adventure Playground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Cornwallis Adventure Playground Facilities",
+        "dataset-site-url": "https://awesomecic.bookteq.com/api/open-active/b4063b7b-1022-4c76-a88d-8add6eb20529/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://awesomecic.bookteq.com/api/open-active/b4063b7b-1022-4c76-a88d-8add6eb20529/slots",
+        "publisher-name": "Cornwallis Adventure Playground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Three Corners Adventure Playground Facilities",
+        "dataset-site-url": "https://awesomecic.bookteq.com/api/open-active/e52f2a55-57f7-40b5-99d5-a8d685350049/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://awesomecic.bookteq.com/api/open-active/e52f2a55-57f7-40b5-99d5-a8d685350049/individual-facility-uses",
+        "publisher-name": "Three Corners Adventure Playground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Three Corners Adventure Playground Facilities",
+        "dataset-site-url": "https://awesomecic.bookteq.com/api/open-active/e52f2a55-57f7-40b5-99d5-a8d685350049/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://awesomecic.bookteq.com/api/open-active/e52f2a55-57f7-40b5-99d5-a8d685350049/slots",
+        "publisher-name": "Three Corners Adventure Playground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bull Lane Playing Fields Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/132e14d3-89c0-4b94-977d-7efc02ef3bf7/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/132e14d3-89c0-4b94-977d-7efc02ef3bf7/individual-facility-uses",
+        "publisher-name": "Bull Lane Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bull Lane Playing Fields Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/132e14d3-89c0-4b94-977d-7efc02ef3bf7/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/132e14d3-89c0-4b94-977d-7efc02ef3bf7/slots",
+        "publisher-name": "Bull Lane Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Down Lane Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/4029789a-9b11-4358-a6c8-044ce0f2ab67/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/4029789a-9b11-4358-a6c8-044ce0f2ab67/individual-facility-uses",
+        "publisher-name": "Down Lane Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Down Lane Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/4029789a-9b11-4358-a6c8-044ce0f2ab67/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/4029789a-9b11-4358-a6c8-044ce0f2ab67/slots",
+        "publisher-name": "Down Lane Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Downhills Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/d523e3cd-a251-490d-aa42-fb4e387ffac7/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/d523e3cd-a251-490d-aa42-fb4e387ffac7/individual-facility-uses",
+        "publisher-name": "Downhills Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Downhills Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/d523e3cd-a251-490d-aa42-fb4e387ffac7/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/d523e3cd-a251-490d-aa42-fb4e387ffac7/slots",
+        "publisher-name": "Downhills Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Muswell Hill Playing Fields Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/f3a22309-717d-475b-b8a7-cd0773d84515/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/f3a22309-717d-475b-b8a7-cd0773d84515/individual-facility-uses",
+        "publisher-name": "Muswell Hill Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Muswell Hill Playing Fields Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/f3a22309-717d-475b-b8a7-cd0773d84515/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/f3a22309-717d-475b-b8a7-cd0773d84515/slots",
+        "publisher-name": "Muswell Hill Playing Fields",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "O.R. Tambo Recreation Ground (formerly Albert Road Rec) Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/520f1024-290e-4b88-8f6e-ef7aed519e41/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/520f1024-290e-4b88-8f6e-ef7aed519e41/individual-facility-uses",
+        "publisher-name": "O.R. Tambo Recreation Ground (formerly Albert Road Rec)",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "O.R. Tambo Recreation Ground (formerly Albert Road Rec) Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/520f1024-290e-4b88-8f6e-ef7aed519e41/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/520f1024-290e-4b88-8f6e-ef7aed519e41/slots",
+        "publisher-name": "O.R. Tambo Recreation Ground (formerly Albert Road Rec)",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Markfield Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/eccf5d5c-9385-40a2-97e4-38f54eb0de54/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/eccf5d5c-9385-40a2-97e4-38f54eb0de54/individual-facility-uses",
+        "publisher-name": "Markfield Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Markfield Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/eccf5d5c-9385-40a2-97e4-38f54eb0de54/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/eccf5d5c-9385-40a2-97e4-38f54eb0de54/slots",
+        "publisher-name": "Markfield Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bankside Update Facilities",
+        "dataset-site-url": "https://nathanlc.bookteq.com/api/open-active/2d3596c2-5bb5-421c-b942-101514f5abf3/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://nathanlc.bookteq.com/api/open-active/2d3596c2-5bb5-421c-b942-101514f5abf3/individual-facility-uses",
+        "publisher-name": "Bankside Update",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bankside Update Facilities",
+        "dataset-site-url": "https://nathanlc.bookteq.com/api/open-active/2d3596c2-5bb5-421c-b942-101514f5abf3/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://nathanlc.bookteq.com/api/open-active/2d3596c2-5bb5-421c-b942-101514f5abf3/slots",
+        "publisher-name": "Bankside Update",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Pastures  Centre Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/bec706b1-302b-4c79-8be0-fbc4d80783da/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/bec706b1-302b-4c79-8be0-fbc4d80783da/individual-facility-uses",
+        "publisher-name": "Pastures  Centre",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Pastures  Centre Facilities",
+        "dataset-site-url": "https://walthamforestcouncil.bookteq.com/api/open-active/bec706b1-302b-4c79-8be0-fbc4d80783da/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://walthamforestcouncil.bookteq.com/api/open-active/bec706b1-302b-4c79-8be0-fbc4d80783da/slots",
+        "publisher-name": "Pastures  Centre",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Jubilee Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/810ed1cf-663d-4a6a-948b-30402c50826e/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/810ed1cf-663d-4a6a-948b-30402c50826e/individual-facility-uses",
+        "publisher-name": "Jubilee Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Jubilee Park Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/810ed1cf-663d-4a6a-948b-30402c50826e/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/810ed1cf-663d-4a6a-948b-30402c50826e/slots",
+        "publisher-name": "Jubilee Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Great Denham Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/f204790b-5975-44ae-b6e9-2969ff51af07/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/f204790b-5975-44ae-b6e9-2969ff51af07/individual-facility-uses",
+        "publisher-name": "Great Denham",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Great Denham Facilities",
+        "dataset-site-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/f204790b-5975-44ae-b6e9-2969ff51af07/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://bedfordboroughcouncil.bookteq.com/api/open-active/f204790b-5975-44ae-b6e9-2969ff51af07/slots",
+        "publisher-name": "Great Denham",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Stanley Primary School Facilities",
+        "dataset-site-url": "https://stanleyprimaryschool.bookteq.com/api/open-active/73f7da0a-9833-4736-8975-944649e3a139/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://stanleyprimaryschool.bookteq.com/api/open-active/73f7da0a-9833-4736-8975-944649e3a139/individual-facility-uses",
+        "publisher-name": "Stanley Primary School",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Stanley Primary School Facilities",
+        "dataset-site-url": "https://stanleyprimaryschool.bookteq.com/api/open-active/73f7da0a-9833-4736-8975-944649e3a139/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://stanleyprimaryschool.bookteq.com/api/open-active/73f7da0a-9833-4736-8975-944649e3a139/slots",
+        "publisher-name": "Stanley Primary School",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "St Aloysius’ College Facilities",
+        "dataset-site-url": "https://staloysiuscollege.bookteq.com/api/open-active/75ac7378-6d85-4ffa-82a7-d1c72bda655e/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://staloysiuscollege.bookteq.com/api/open-active/75ac7378-6d85-4ffa-82a7-d1c72bda655e/individual-facility-uses",
+        "publisher-name": "St Aloysius’ College",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "St Aloysius’ College Facilities",
+        "dataset-site-url": "https://staloysiuscollege.bookteq.com/api/open-active/75ac7378-6d85-4ffa-82a7-d1c72bda655e/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://staloysiuscollege.bookteq.com/api/open-active/75ac7378-6d85-4ffa-82a7-d1c72bda655e/slots",
+        "publisher-name": "St Aloysius’ College",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Durdans Park Cricket Ground Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/ed4465b9-e89f-42c9-8828-19b2c17c03d7/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/ed4465b9-e89f-42c9-8828-19b2c17c03d7/individual-facility-uses",
+        "publisher-name": "Durdans Park Cricket Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Durdans Park Cricket Ground Facilities",
+        "dataset-site-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/ed4465b9-e89f-42c9-8828-19b2c17c03d7/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://ealingboroughcouncil.bookteq.com/api/open-active/ed4465b9-e89f-42c9-8828-19b2c17c03d7/slots",
+        "publisher-name": "Durdans Park Cricket Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Chestnuts Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/0236e84c-4a89-4aa2-9405-18dad1c4bf85/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/0236e84c-4a89-4aa2-9405-18dad1c4bf85/individual-facility-uses",
+        "publisher-name": "Chestnuts Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Chestnuts Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/0236e84c-4a89-4aa2-9405-18dad1c4bf85/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/0236e84c-4a89-4aa2-9405-18dad1c4bf85/slots",
+        "publisher-name": "Chestnuts Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Priory Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/07dd551f-4b0a-41b0-98b8-216bddf1db1e/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/07dd551f-4b0a-41b0-98b8-216bddf1db1e/individual-facility-uses",
+        "publisher-name": "Priory Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Priory Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/07dd551f-4b0a-41b0-98b8-216bddf1db1e/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/07dd551f-4b0a-41b0-98b8-216bddf1db1e/slots",
+        "publisher-name": "Priory Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Wood Green Common Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/0ac3a8d3-d42f-43ad-a8b8-a52be7e0a480/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/0ac3a8d3-d42f-43ad-a8b8-a52be7e0a480/individual-facility-uses",
+        "publisher-name": "Wood Green Common",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Wood Green Common Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/0ac3a8d3-d42f-43ad-a8b8-a52be7e0a480/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/0ac3a8d3-d42f-43ad-a8b8-a52be7e0a480/slots",
+        "publisher-name": "Wood Green Common",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Russell Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/38696fde-e5a4-48ae-89c0-56c7e88ab86b/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/38696fde-e5a4-48ae-89c0-56c7e88ab86b/individual-facility-uses",
+        "publisher-name": "Russell Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Russell Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/38696fde-e5a4-48ae-89c0-56c7e88ab86b/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/38696fde-e5a4-48ae-89c0-56c7e88ab86b/slots",
+        "publisher-name": "Russell Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bruce Castle Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/eaf01180-6f8a-4775-9a2b-3e121433cda4/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/eaf01180-6f8a-4775-9a2b-3e121433cda4/individual-facility-uses",
+        "publisher-name": "Bruce Castle Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Bruce Castle Park Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/eaf01180-6f8a-4775-9a2b-3e121433cda4/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/eaf01180-6f8a-4775-9a2b-3e121433cda4/slots",
+        "publisher-name": "Bruce Castle Park",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Ducketts Common Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/a9c98e21-228b-4698-bf1c-a19c7a14ceef/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/a9c98e21-228b-4698-bf1c-a19c7a14ceef/individual-facility-uses",
+        "publisher-name": "Ducketts Common",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Ducketts Common Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/a9c98e21-228b-4698-bf1c-a19c7a14ceef/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/a9c98e21-228b-4698-bf1c-a19c7a14ceef/slots",
+        "publisher-name": "Ducketts Common",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Lordship Recreation Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/dbfab809-aeec-47d3-87b1-c36810fc7cbd/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/dbfab809-aeec-47d3-87b1-c36810fc7cbd/individual-facility-uses",
+        "publisher-name": "Lordship Recreation",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "Lordship Recreation Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/dbfab809-aeec-47d3-87b1-c36810fc7cbd/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/dbfab809-aeec-47d3-87b1-c36810fc7cbd/slots",
+        "publisher-name": "Lordship Recreation",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "White Hart Lane Recreation Ground Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/fb85e2aa-538c-49f7-83b5-eb1a9998e243/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "IndividualFacilityUse",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/fb85e2aa-538c-49f7-83b5-eb1a9998e243/individual-facility-uses",
+        "publisher-name": "White Hart Lane Recreation Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    },
+    {
+        "title": "White Hart Lane Recreation Ground Facilities",
+        "dataset-site-url": "https://haringeycouncil.bookteq.com/api/open-active/fb85e2aa-538c-49f7-83b5-eb1a9998e243/",
+        "discussion-url": "https://github.com/playfinder/openactive/issues",
+        "feed-type": "Slot",
+        "data-url": "https://haringeycouncil.bookteq.com/api/open-active/fb85e2aa-538c-49f7-83b5-eb1a9998e243/slots",
+        "publisher-name": "White Hart Lane Recreation Ground",
+        "license-url": "https://creativecommons.org/licenses/by/4.0/",
+        "publish": "true"
+    }
+]

--- a/lib/datasets_cache.rb
+++ b/lib/datasets_cache.rb
@@ -1,8 +1,32 @@
+class Datasets
+
+  DIRECTORY="https://www.openactive.io/datasets/directory.json"
+
+  #Returns a hash of datasets keyed on a unique id.
+  def self.list
+    resp = RestClient.get( DIRECTORY )
+    results = JSON.parse(resp.body)
+    datasets = {}
+    results.each do |result|
+      begin
+        next unless result["publish"] && result["publish"] == true
+        dataset_key = result["documentation-url"].gsub("https://github.com/", "")
+        dataset_key.chomp!("/")
+        datasets.merge!({ dataset_key => result })
+      rescue => e
+        #ignore errors
+      end
+    end
+    datasets
+  end
+end
+end
+
 class DatasetsCache
 
   def self.update
     begin
-      datasets = OpenActive::Datasets.list
+      datasets = Datasets.list
       datasets = update_conformance(datasets)
       datasets = update_github_issues(datasets)
       datasets = update_has_coordinates(datasets)

--- a/lib/datasets_cache.rb
+++ b/lib/datasets_cache.rb
@@ -1,16 +1,15 @@
 class Datasets
 
-  DIRECTORY="https://www.openactive.io/datasets/directory.json"
+  DIRECTORY="./directory.json"
 
   #Returns a hash of datasets keyed on a unique id.
   def self.list
-    resp = RestClient.get( DIRECTORY )
-    results = JSON.parse(resp.body)
+    results = JSON.load(File.open(DIRECTORY))
     datasets = {}
     results.each do |result|
       begin
-        next unless result["publish"] && result["publish"] == true
-        dataset_key = result["documentation-url"].gsub("https://github.com/", "")
+        next unless result["publish"] && result["publish"] == "true" && result["publisher-name"]
+        dataset_key = result["data-url"]
         dataset_key.chomp!("/")
         datasets.merge!({ dataset_key => result })
       rescue => e
@@ -19,7 +18,6 @@ class Datasets
     end
     datasets
   end
-end
 end
 
 class DatasetsCache
@@ -94,8 +92,9 @@ class DatasetsCache
 
   def self.update_github_issues(datasets)
     for dataset_key in datasets.keys
+      dataset = datasets[dataset_key]
       begin
-        git_resp = RestClient.get('https://api.github.com/repos/'+ dataset_key +'/issues')
+        git_resp = RestClient.get(dataset["discussion-url"].gsub('https://github.com/','https://api.github.com/repos/'))
         issues = JSON.parse(git_resp.body)
         datasets[dataset_key].merge!({ "github-issues" => issues.size })
       rescue

--- a/public/css/oa-dashboard.css
+++ b/public/css/oa-dashboard.css
@@ -11,7 +11,6 @@ body {
   min-height: 94vh;
   position:relative;
   padding-bottom: 200px;
-
 }
 
 .center, .centre { text-align:center; }
@@ -127,3 +126,22 @@ a {
 .btn-primary:hover {
   background-color: #fc9b9b;
 }
+
+#word_container {
+  position: absolute;
+  margin: auto;
+  width: 100vw;
+  height: 40pt;
+  filter: url(#threshold) blur(0.6px);
+}
+
+#text1, #text2 {
+  position: absolute;
+  width: 100%;
+  display: inline-block;
+  font-size: 40pt;
+  text-align: center;
+  user-select: none;
+}
+
+

--- a/views/index.erb
+++ b/views/index.erb
@@ -3,6 +3,7 @@
     <h1 class="">OpenActive Opportunity Data Dashboard</h1>
     <p>This dashboard lists all of the datasets and APIs published as part of the OpenActive initiative.</p>
     <p>From these feeds, you can harvest data about sporting and physical activities from across the UK.</p>
+    <p>The feeds listed here are those included in the <a href="https://openactive.io/data-catalogs/data-catalog-collection.jsonld">OpenActive data catalog</a>.</p>
     <p><a href="/about">Read more about opportunity data.</a></p>
   </div>
 </header>
@@ -14,8 +15,8 @@
   <thead>
   <tr>
     <th scope="col">Provider</th>
-    <th scope="col">Endpoint</th>
-    <th scope="col">Summary</th>
+    <th scope="col">Type of feed</th>
+    <th scope="col">API Endpoint</th>
     <th scope="col">Issues</th>
     <th scope="col">Licence</th>
   </tr>
@@ -26,24 +27,24 @@
       <td>
         <a href="<%= dataset["dataset-site-url"] %>" target="_blank"><%= dataset["publisher-name"] %></a><br/>
       </td>
+      <td>
+        <%= dataset["feed-type"] %> <br/>
+      </td>
       <td class="endpoint-availability">
         <a href="<%= dataset["data-url"] %>" target="_blank">
           <%= availability_indicator(availability, dataset["data-url"]) %>
         </a>
       </td>
       <td>
-        <% if dataset["uses-paging-spec"] and dataset["uses-opportunity-model"] %>
-          <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#<%= key.gsub("/", "-") %>"><span style="display:none;">a</span>View</button>
-        <% else %>
-          <button type="button" disabled="disabled" class="btn btn-gray" title="Summary not available for this dataset">View</button>
-        <% end %>
-      </td>
-      <td>
-        <a href="<%= dataset["documentation-url"] %>/issues" target="_blank">
+        <% if dataset["discussion-url"].empty? %>
+        -
+        <% else %> 
+        <a href="<%= dataset["discussion-url"] %>" target="_blank">
         <% if dataset["github-issues"].nil? %>
           -
         <% else %>
           <%= dataset["github-issues"] %>
+        <% end %>
         <% end %>
         </a>
       </td>
@@ -60,84 +61,4 @@
 <a class="btn btn-secondary" href="/datasets.json" download="openactive-datasets.json" target="_blank">Download JSON List</a></p>
 
 <small><a href="#page-wrapper">[top]</a></small>
-</div>
-
-<div class="summary-modals">
-  <% for key in datasets.keys; id = key.gsub("/", "-"); dataset = datasets[key] %>
-    <div class="modal fade" id="<%= id %>" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" data-dataset-key="<%= key %>" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLabel"><%= dataset["publisher-name"] %> Dataset Summary</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <svg class="lds-spin" width="10%" height="10%" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid"><g transform="translate(80,50)">
-              <g transform="rotate(0)">
-              <circle cx="0" cy="0" r="7" fill="#69b9ff" fill-opacity="1" transform="scale(1.01042 1.01042)">
-              <animateTransform attributeName="transform" type="scale" begin="-0.7000000000000001s" values="1.1 1.1;1 1" keyTimes="0;1" dur="0.8s" repeatCount="indefinite"></animateTransform>
-              <animate attributeName="fill-opacity" keyTimes="0;1" dur="0.8s" repeatCount="indefinite" values="1;0" begin="-0.7000000000000001s"></animate>
-              </circle>
-              </g>
-              </g><g transform="translate(71.21320343559643,71.21320343559643)">
-              <g transform="rotate(45)">
-              <circle cx="0" cy="0" r="7" fill="#69b9ff" fill-opacity="0.875" transform="scale(1.02292 1.02292)">
-              <animateTransform attributeName="transform" type="scale" begin="-0.6000000000000001s" values="1.1 1.1;1 1" keyTimes="0;1" dur="0.8s" repeatCount="indefinite"></animateTransform>
-              <animate attributeName="fill-opacity" keyTimes="0;1" dur="0.8s" repeatCount="indefinite" values="1;0" begin="-0.6000000000000001s"></animate>
-              </circle>
-              </g>
-              </g><g transform="translate(50,80)">
-              <g transform="rotate(90)">
-              <circle cx="0" cy="0" r="7" fill="#69b9ff" fill-opacity="0.75" transform="scale(1.03542 1.03542)">
-              <animateTransform attributeName="transform" type="scale" begin="-0.5s" values="1.1 1.1;1 1" keyTimes="0;1" dur="0.8s" repeatCount="indefinite"></animateTransform>
-              <animate attributeName="fill-opacity" keyTimes="0;1" dur="0.8s" repeatCount="indefinite" values="1;0" begin="-0.5s"></animate>
-              </circle>
-              </g>
-              </g><g transform="translate(28.786796564403577,71.21320343559643)">
-              <g transform="rotate(135)">
-              <circle cx="0" cy="0" r="7" fill="#69b9ff" fill-opacity="0.625" transform="scale(1.04792 1.04792)">
-              <animateTransform attributeName="transform" type="scale" begin="-0.4s" values="1.1 1.1;1 1" keyTimes="0;1" dur="0.8s" repeatCount="indefinite"></animateTransform>
-              <animate attributeName="fill-opacity" keyTimes="0;1" dur="0.8s" repeatCount="indefinite" values="1;0" begin="-0.4s"></animate>
-              </circle>
-              </g>
-              </g><g transform="translate(20,50.00000000000001)">
-              <g transform="rotate(180)">
-              <circle cx="0" cy="0" r="7" fill="#69b9ff" fill-opacity="0.5" transform="scale(1.06042 1.06042)">
-              <animateTransform attributeName="transform" type="scale" begin="-0.30000000000000004s" values="1.1 1.1;1 1" keyTimes="0;1" dur="0.8s" repeatCount="indefinite"></animateTransform>
-              <animate attributeName="fill-opacity" keyTimes="0;1" dur="0.8s" repeatCount="indefinite" values="1;0" begin="-0.30000000000000004s"></animate>
-              </circle>
-              </g>
-              </g><g transform="translate(28.78679656440357,28.786796564403577)">
-              <g transform="rotate(225)">
-              <circle cx="0" cy="0" r="7" fill="#69b9ff" fill-opacity="0.375" transform="scale(1.07292 1.07292)">
-              <animateTransform attributeName="transform" type="scale" begin="-0.2s" values="1.1 1.1;1 1" keyTimes="0;1" dur="0.8s" repeatCount="indefinite"></animateTransform>
-              <animate attributeName="fill-opacity" keyTimes="0;1" dur="0.8s" repeatCount="indefinite" values="1;0" begin="-0.2s"></animate>
-              </circle>
-              </g>
-              </g><g transform="translate(49.99999999999999,20)">
-              <g transform="rotate(270)">
-              <circle cx="0" cy="0" r="7" fill="#69b9ff" fill-opacity="0.25" transform="scale(1.08542 1.08542)">
-              <animateTransform attributeName="transform" type="scale" begin="-0.1s" values="1.1 1.1;1 1" keyTimes="0;1" dur="0.8s" repeatCount="indefinite"></animateTransform>
-              <animate attributeName="fill-opacity" keyTimes="0;1" dur="0.8s" repeatCount="indefinite" values="1;0" begin="-0.1s"></animate>
-              </circle>
-              </g>
-              </g><g transform="translate(71.21320343559643,28.78679656440357)">
-              <g transform="rotate(315)">
-              <circle cx="0" cy="0" r="7" fill="#69b9ff" fill-opacity="0.125" transform="scale(1.09792 1.09792)">
-              <animate attributeName="fill-opacity" keyTimes="0;1" dur="0.8s" repeatCount="indefinite" values="1;0" begin="0s"></animate>
-              </circle>
-              </g>
-              </g>
-            </svg>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-  <% end %>
 </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,18 +1,9 @@
-b<header class="jumbotron">
+<header class="jumbotron">
   <div class="container">
     <h1 class="">OpenActive Opportunity Data Dashboard</h1>
-    <p>
-    <!--  This dashboard lists all of the datasets and APIs published as part of the OpenActive initiative.
-      From these feeds, you can harvest data about sporting and physical activities from across the UK.
-      <a href="/about">Read more about opportunity data</a>. -->
-      This dashboard is intended to list all datasets and APIs published as part of the OpenActive initiative. <b>However, owing to our recent significant increase in scale, not all OpenActive implementer feeds are listed below</b>. A further list of available datasets can be found in our <a href="https://docs.google.com/document/d/e/2PACX-1vShUnBhlPXyPPjSlaaMbVQClp3Pev28CCI5G8lWYwKLFd0-qyqyOLBb9kW_NX96-vH-WI5kfN6jlqiN/pub">OpenActive Supplemental Status Page</a>.
-    </p>
-  The technical work needed to integrate these datasets into the main status page is intended to commence September 2021.
-    </p>
-    <p>
-      Using this dashboard you can see which data publishers support <a href="https://www.w3.org/community/openactive/">the OpenActive
-      standards</a> and explore summaries of the standardised data.
-    </p>
+    <p>This dashboard lists all of the datasets and APIs published as part of the OpenActive initiative.</p>
+    <p>From these feeds, you can harvest data about sporting and physical activities from across the UK.</p>
+    <p><a href="/about">Read more about opportunity data.</a></p>
   </div>
 </header>
 
@@ -24,11 +15,6 @@ b<header class="jumbotron">
   <tr>
     <th scope="col">Provider</th>
     <th scope="col">Endpoint</th>
-    <th scope="col">
-      <a target="_blank" title="Read paging specification" href="https://www.openactive.io/realtime-paged-data-exchange/">Uses paging spec?</a></th>
-    <th scope="col">
-      <a target="_blank" title="Read opportunity data specification" href="https://www.openactive.io/modelling-opportunity-data/">Uses opportunity model?</a></th>
-    <th scope="col">Includes coordinates?</th>
     <th scope="col">Summary</th>
     <th scope="col">Issues</th>
     <th scope="col">Licence</th>
@@ -45,25 +31,6 @@ b<header class="jumbotron">
           <%= availability_indicator(availability, dataset["data-url"]) %>
         </a>
       </td>
-      <td>
-        <% if dataset["uses-paging-spec"] %>
-          <a href="https://validator.openactive.io/rpde?url=<%= ERB::Util.u(dataset["data-url"]) %>" target="_blank">
-            <%= yesno_indicator(dataset["uses-paging-spec"]) %>
-          </a>  
-        <% else %>
-          <%= yesno_indicator(dataset["uses-paging-spec"]) %>
-        <% end %>
-      </td>
-      <td>
-        <% if dataset["uses-opportunity-model"] %>
-          <a href="https://validator.openactive.io/?url=<%= ERB::Util.u(dataset["data-url"]) %>" target="_blank">
-            <%= yesno_indicator(dataset["uses-opportunity-model"]) %>
-          </a>  
-        <% else %>
-          <%= yesno_indicator(dataset["uses-opportunity-model"]) %>
-        <% end %>
-      </td>
-      <td><%= yesno_indicator(dataset["has-coordinates"]) %></td>
       <td>
         <% if dataset["uses-paging-spec"] and dataset["uses-opportunity-model"] %>
           <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#<%= key.gsub("/", "-") %>"><span style="display:none;">a</span>View</button>

--- a/views/insights.erb
+++ b/views/insights.erb
@@ -1,0 +1,112 @@
+<br/><br/>
+<section class="container">
+
+<h1>OpenActive Insights</h1>
+
+  <p>This page showcases facts, stats and interesting findings emerging from the OpenActive data feeds.</p>
+
+<br/>
+</section>
+<section class="container">
+<p>How many of the OpenActive activities have you tried?</p>
+</section>
+
+<div id="word_container">
+    <span id="text1"></span>
+    <span id="text2"></span>
+</div>
+
+<svg id="filters">
+    <defs>
+        <filter id="threshold">
+            <feColorMatrix in="SourceGraphic" type="matrix" values="1 0 0 0 0
+									0 1 0 0 0
+									0 0 1 0 0
+									0 0 0 255 -140" />
+        </filter>
+    </defs>
+</svg>
+
+
+
+<script type="text/javascript">
+
+const elts = {
+    text1: document.getElementById("text1"),
+    text2: document.getElementById("text2")
+};
+
+const texts = [
+  'Voguing', 'Wheelchair Fencing', 'Kayaking', 'Popdance Kids', 'Tag Rugby', 'Lindy Hop', 'Schooling', 'Synchronised Swimming', 'Hydro Therapy', 'Metafit', 'Roller Hockey', 'Show Jumping', 'Field Hockey', 'Camogie', 'Pickleball', 'Inclusive Zone Basketball', 'Karate', 'Squash', 'Kendo', 'Ice Hockey', 'Waacking', 'Forrest Yoga', 'Hacking', 'Cheer Dance', 'Mambo', 'Kfa Moves', 'Ropes Courses', 'VIPR', 'Personal Training', 'Kettlercise', 'Popdance Adults', 'Biathlon', 'Eventing', 'PWR-Beatz', 'Aqua Jogging', 'Classic Nia', 'Badminton', 'Clay Pigeon', 'Wushu', 'Popping', 'Cheerobics®', 'Handball', 'Nia', 'Karting', 'Systema', 'Full Course Golf', '20-20-20', 'Racing', 'Open Water Swimming', 'Ten-Pin Bowling', 'Dog Walking', 'Party Fitness', 'Pilates', 'Tap', 'Stretch Class', 'Bhangra Fitness', 'Mixed Martial Arts', 'Iyengar Yoga', 'Texas Scramble Golf', 'Martial Arts', 'Barreconcept', 'Gymnastics', 'Deck Bowls', 'KFA Seated/Chair', 'Hip Hop', 'Wheelchair Basketball', 'DDmix', 'Bobsleigh', 'Street Step', 'Combi Dance Sport', 'Resistance weights machines', 'Padel Tennis', 'Modern', 'Adventure Golf', 'Bowls', 'Melbourne Shuffle', 'Top Rope Climbing', 'Flexaware', 'Step machine', 'Alpine Skiing', 'Bounce', 'Cheer Fitness', 'Chasamba®', 'Bokwa', 'Zumba® Gold Toning', 'Driving Range', 'Cross training machine', '6-a-side', 'Capoeira', 'Legs Bums And Tums', 'Hooptone', 'Wild Water Rafting', 'Rock and Roll', 'Javelin Throw', 'Cx Worx™', 'Wheelchair Ballroom Dancing', 'Water-Based Classes', 'Rockbox Fitness', 'Greek Dancing', 'Cross Country Skiing', 'Tchoukball', 'Fencing', 'Cycling', 'Funk', 'Rugby Sevens', 'Land Sailing', 'Cross Fit', 'Target Shooting', 'Sheaf toss', 'Stoolball', 'Snowboard Racing', 'Hoop Dance', 'Multisports', 'Blast Fx', 'Water Skiing', 'Aerial', 'Salsa Fitness', 'Basketball', 'Athletics', 'Tug Of War', 'Piloxing Knockout', 'Fell Walking', 'Les Mills Tone™', 'Zumba Glow', 'Shooting', 'Piloxing Barre', 'Polybat', 'Freestyle', 'Deaf Tennis', 'Aqua Dance', 'Ballroom and Latin Fitness', 'Gardening', 'Stone put', 'Gaelic Football', 'BODY VIVE®', 'CIZE', 'P90X', 'World Jumping®', 'Freestyle Snowboarding', 'Air Fit', 'Motor Cycling', 'Equestrian', 'Abseiling', 'Crossfit', 'Dance Fitness', 'Kung Fu', 'Armageddon Fitness', 'Sh1ft', 'Dressage', 'Popdance Teens', 'Body Combat™', 'Fitness Yoga', 'Ballestics', 'Shinty', 'House', 'Konga®', 'Powerboating', 'Irish Dancing', 'Golf', 'Bikram Yoga', 'Jagua®', 'Walking Rugby', 'High Ropes', 'Tai Chi', 'Jiggy Jump', 'AzontoBeats', 'Volleyball', 'Boxing', 'Callanetics', 'Snooker', 'Kobudo', 'KpopX', 'Track Cycling', 'Flamenco', 'Golf Xtreme', 'Meditation', 'Chinese Movement & Dance Fitness', 'Bodyattack™', 'Step Aerobics', 'Sailing', 'Obstacle Course Racing', 'Ballet Fitness', 'Street Dance Fitness', 'Snorkelling', 'Caber toss', 'TRE', 'Hill Walking', 'Hurling', 'Hockey', 'Yogalates™', 'Kwik Cricket', 'Insanity', 'Ju-Jitsu', 'Airgun', 'Carnival', 'Hiking', 'Kundalini Yoga', 'Snatch', 'Visually Impaired Tennis', 'Cricket nets', 'Zumba Strong®', 'Jukari Fit To Flex', 'Hula Fitness', 'Water Polo', 'Caving', 'Hammer Throw', 'Gym Workout', 'Core Stability', 'Bosu®', 'Latin', 'Strutology', 'Belrobics', 'Kfa Creative Moves', 'Foxtrot', 'Body Conditioning', 'Barre', 'Flexibility/Stretching', 'Rowing', 'Clean and Jerk', 'Viennese Waltz', 'Kickboxing', 'Crown Green Bowls', 'Ballroom And Latin', 'Bouldering', 'Billiards', 'Bounce Dancefit', 'New Body', 'Beam Fit', 'Table Tennis', 'Dancercise', 'Weight over the bar', 'Rebound', 'Vinyasa Yoga', 'Muzzle loading', 'Aqua Fit', 'Muay Thai', 'Power Walking', 'Sit N B Fit', 'Windsurfing', 'Country And Western Fitness', 'Medau', 'Scuba Diving', 'Stability Ball', 'Rugby League', 'Jive', 'Line Dancing', 'Highland Hustle', 'Roller Skating', 'Power Pilates', 'Wheelchair Rugby', 'Powerhoop', 'Snowboarding', 'Boxfit', 'Polo', 'Contemporary', 'Waltz', 'Burlexercise', 'American Football', 'Sprint®', 'Flexibar', 'Fight Fx', 'Yoga Nidra', 'Hour of Power', 'CORE DE FORCE', 'Boxercise', 'Scaravelli Inspired Yoga', 'Practice nets', 'Stand Up Paddleboarding', 'Sweaty Mama', 'Jivamukti Yoga', 'Boxing Fitness', 'Walking Football', 'Bhangra', 'Aquathon', 'Sand Yachting', 'Aerobics', 'Argentine Tango', 'Mash It Up', 'Jet Skiing', 'Walking Tennis', 'Suspension', 'Softball', 'Jump Fx', 'Powerbags', 'Dragon Boat Racing', 'Low Ropes', 'Boules', 'Long Jump', 'Waterworks', 'Octopush', 'Globe Fit Hoola', 'Clubbercise', 'Table Cricket', 'Born To Move', 'Speed Climbing', 'Veraflow', 'Tango', 'Ravercise', 'Street Dance', 'Parkour', 'Para Gliding', 'Boogie Bounce', 'Highland Games', 'Zumba® Toning', 'MetaPWR', 'Azonto', '11-a-side', 'Rollerskiing', 'Squash 57', 'Polka', 'Punch And Strike', 'Mountaineering', 'Archery', 'Skipping', 'Pistol', 'Zumba Sentao™', 'Divacise', 'Tennis', 'Indoor Volleyball', 'Otago', 'Deep HAU2', 'Stretch And Tone', 'Gaelic Games', 'Mountain Walking', 'Commuter Cycling', 'Swiss Ball', 'Hulacise', 'Dharma Yoga', 'Rhythmic Gymnastics', 'Sitting Volleyball', 'Pole Vault', 'Sequence Dancing', 'Tobagganing', 'Baby Yoga', 'Pound™', 'Kelta Fit', 'Buggy Fitness', 'Roller Sports', 'Climbing', 'Aqua Aerobics', 'Dancehall', 'Groove Fx', 'PowerWave™', 'Aikido', 'Azonto Fitness', 'Small Sided Football', 'Walking Basketball', 'Krump', 'Speedway', 'Scottish Dance Fitness', 'Power Plate', 'Burlesque Chair Dance', 'Martial Arts Fitness', 'Kathak', 'African Dance', 'Locking', 'Nordic Walking', 'Commercial', 'Footgolf', 'Broga', 'Polocrosse', 'Road Cycling', 'Jazz', 'Kfa Youth Moves', 'Wheelchair Dance Sport', 'Group Exercise', 'Pole Fitness', 'Angling', 'Be-Bop', 'Pitch And Putt', 'Fuse Fit', 'Dance', 'Surfing', 'Popdance Active & Able', 'Lishi', 'Burn', 'Piyo®', 'Wrestling', 'Diving', 'Fell Running', 'Shot Put', 'Touch Rugby League', 'Hot Hula Fitness', 'Cubatone', 'Interval Training', 'Extend', 'Australian Rules Football', 'Alpine Ski Racing', 'Pool', 'Fit-Beatz', 'Freez', 'Triathlon', 'Netball', 'Kfa Body Moves', 'Chiball', 'Voga', 'Multi Dance', 'Booiaka®', 'Urban', 'Burlesque', 'Taekwondo', 'Zumba® Gold', 'Short Mat Bowls', 'Rowing machine', 'Synergy®', 'Track and Field', 'Walking Netball', 'Handcycling', 'Body Jam™', 'Buggy Boot Camp', 'Booty Barre', 'Luge', 'Self Defence', 'Fierce', 'Ballooning', 'Air', 'Ashtanga Yoga', 'Country And Western', 'Long Form Cricket', 'Shbam™', 'Skeleton Racing', 'Boccia', 'Wheelchair Tennis', 'Pole Dancing', 'Beach Volleyball', 'Goalball', 'Block Fit', 'Futsal', 'Running', 'Treadmill', 'Les Mills Grit™', 'Lead Climbing', 'Weight Training', 'Korfball', 'Salsa', 'Dru Yoga', 'Bollywood Bhangra', 'Tabata', 'Speedgolf', 'Qigong', 'Body Attack', 'Bicycle Polo', 'Yoga Rave', 'Geocaching', 'Exercise machine', 'Resistance Bands', 'Paintball', 'Roller Derby', 'Roller Blading', 'Aerial Discipline', 'Street Fit', 'Chakra Dance', 'Board Surfing', 'Buggy Bounce', 'Motor Sport', 'Scottish Dance', 'Hovering', 'Crossbow', '7-a-side', 'Samba', 'Hydro Spin', 'Zumba® Kids', 'Weightlifting', 'Powerchair Football', 'Exercise Ball', 'Skateboarding', 'Fives', 'Warm Yoga', 'Sombo', 'Swimming', 'Mysore Style Ashtanga Yoga', 'Morris Dancing', 'Curling', 'Hotpod Yoga', 'Weight throw', 'Trampoline Fitness', 'drumnbounce', 'Bodypump™', 'Sailability', 'Vypa®', 'Zumba® Step', 'Bootcamp', 'Modern Pentathlon', 'Pony Trekking', 'Eton', 'Blind Football', 'Acroyoga', 'Kangoo Jumps™', 'Functional Fitness', 'Dance Moves', 'Swimming Lessons', 'Fabs', 'Outdoor Badminton', 'Bhangracise', 'Aqua HIIT', 'Para-Badminton', 'Kfa Mature Moves', 'Canoe Polo', 'Bodybalance™', 'Krav Maga', 'Para Dance', 'Exercise bike', 'Bachata', 'Body Surfing', 'Short Tennis', 'Quoits', 'Ice Skating', '8-a-side', 'Animal Flow®', 'Trx®', 'Trigger Point', 'Lacrosse', 'Rabble', 'Platform Diving', 'Folk Dance', 'Horton Technique', 'Aquabike', 'Fitball', 'Cross Training', 'Judo', 'Aqua Zumba®', 'Jogging', 'Kurling', 'Duathlon', 'Brazilian jiu-jitsu', 'Deaf Basketball', 'Yin Yoga', 'Jazz Fitness', 'Sosa™', 'Moves FItness', 'Wakeboarding', 'Jumpstyle', 'Rafting', 'Carpet Bowls', 'Kettlebells', 'Ninjutsu', 'Flat Green Bowls', 'Tang Soo Do', 'Fitsteps®', 'Baton Twirling', 'Country Heat', 'Run/Bike', 'Nova', 'Skiptrix®', 'Rave Fitness', 'Hang Gliding', 'Popdance Fit', 'Wallball', 'Ceroc', 'Swing', 'Mountain Biking', 'Majorettes', 'Parachuting', 'FREESTYLER', 'British Military Fitness', 'Aerial Hoop', 'Chess-Boxing', 'White Water Rafting', 'Flowetic®', 'Square Dancing', 'MovNat', 'Bellydance Fitness', 'Turbo KICK', 'Walking Cricket', 'Wheelchair Football', 'Aquacise', 'Spinning', 'Just Jhoom!', 'HIIT', 'Multi Fitness', 'Harness Racing', 'Trampolining', 'Chi Kung', 'Speed Skating', 'Cyclo-Cross', 'Funky HAU2', 'American Smooth', 'FLexercise', 'Dodgeball', 'Tap Fitness', 'Cricket', 'Salsa Aerobics', 'Swimfit', 'Orienteering', 'Abs/Core', 'Football', 'Circuit Training', 'Barrecore', 'Nordic Skiing', 'Walking Hockey', 'Lyrical', 'Natural Movement', 'Powerkiting', 'Scottish Hammer throw', 'Methodology X', 'Globe Fit', 'Body Boarding', 'Soft Play', 'Yoga', 'Short Course Golf', 'Horseball', 'Swing Train', 'Artistic Gymnastics', 'Knee Boarding', 'Running machine', 'Pachanga', 'Petanque', 'Gaelic Handball', 'Disco', 'Rounders', 'Restorative Yoga', 'Flag Football', 'Cheerleading', 'Pump Fx', 'Hulafit', 'diddi dance', 'High Jump', 'Zumba® Kids Jr.', 'Bolero', 'Indoor Cycling', 'Croquet', 'Burlesque Dance Fitness', 'Chair Based Exercise', 'Zumba®', 'Tri-Golf', 'Dance Aerobics', 'Aquathlon', 'Bag-Fit', 'Figure Skating', 'Horse Racing', 'This Girl Can Classes', 'Lifesaving Sport', 'Walking', 'Cha-Cha-Cha', 'Recreational Cycling', 'Zumbini®', 'Rugby Union', 'Powerlifting', 'Clubbercise Kids', 'Floorball', 'Belly Dance', 'Barrys Bootcamp', 'Popdance Tots', 'FloatFit', 'Charleston', 'Street Cheer', 'Bollywood', 'Darts', 'Hatha Yoga', 'Rugby', 'Touch Rugby Union', 'Medau Movement', 'Rifle', 'Clay Target', 'Bmx Racing', 'Club Cardio', 'Merengue', 'Tyga®', 'Hot Yoga', 'Rpm™', 'Short Form Cricket', 'Baseball', 'Kite Surfing', 'Canoeing', 'Ballet', 'Breathwork', 'Chinese Movement & Dance', 'Gliding', 'Piloxing', 'Shotgun', 'Aqua Fit (Deep Water)', 'Bollywood Fitness', 'Rumba', 'Medicine Ball', 'Arm Wrestling', 'SkipFit', 'Kabaddi', 'KFA', 'Bodystep™', 'Indoor Rowing', 'Real Tennis', 'Circus Skills', 'Break Dance', 'Quick Step', 'Mini-Beatz', 'Rock Climbing', 'Jazzercise', 'Skiing', 'Kfa Fit Moves', 'Aqua Fit (Shallow Water)', 'Discus Throw', '9-a-side', 'Pasa Doble', 'Ultimate Frisbee', '5-a-side'
+];
+
+const morphTime = 1;
+const cooldownTime = 0.25;
+
+let textIndex = texts.length - 1;
+let time = new Date();
+let morph = 0;
+let cooldown = cooldownTime;
+
+elts.text1.textContent = texts[textIndex % texts.length];
+elts.text2.textContent = texts[(textIndex + 1) % texts.length];
+
+function doMorph() {
+    morph -= cooldown;
+    cooldown = 0;
+
+    let fraction = morph / morphTime;
+
+    if (fraction > 1) {
+        cooldown = cooldownTime;
+        fraction = 1;
+    }
+
+    setMorph(fraction);
+}
+
+function setMorph(fraction) {
+    elts.text2.style.filter = `blur(${Math.min(8 / fraction - 8, 100)}px)`;
+    elts.text2.style.opacity = `${Math.pow(fraction, 0.4) * 100}%`;
+
+    fraction = 1 - fraction;
+    elts.text1.style.filter = `blur(${Math.min(8 / fraction - 8, 100)}px)`;
+    elts.text1.style.opacity = `${Math.pow(fraction, 0.4) * 100}%`;
+
+    elts.text1.textContent = texts[textIndex % texts.length];
+    elts.text2.textContent = texts[(textIndex + 1) % texts.length];
+}
+
+function doCooldown() {
+    morph = 0;
+
+    elts.text2.style.filter = "";
+    elts.text2.style.opacity = "100%";
+
+    elts.text1.style.filter = "";
+    elts.text1.style.opacity = "0%";
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+
+    let newTime = new Date();
+    let shouldIncrementIndex = cooldown > 0;
+    let dt = (newTime - time) / 1000;
+    time = newTime;
+
+    cooldown -= dt;
+
+    if (cooldown <= 0) {
+        if (shouldIncrementIndex) {
+            textIndex++;
+        }
+
+        doMorph();
+    } else {
+        doCooldown();
+    }
+}
+
+animate();
+</script>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -41,12 +41,6 @@
         <a class="nav-link" href="https://www.openactive.io/">Open your data</a>
       </li>
 
-      <li class="nav-item">
-      <a class="nav-link" href="/insights">Insights</a>
-    </li>
-
-
-
     </ul>
   </div>
 </nav>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -41,6 +41,11 @@
         <a class="nav-link" href="https://www.openactive.io/">Open your data</a>
       </li>
 
+      <li class="nav-item">
+      <a class="nav-link" href="/insights">Insights</a>
+    </li>
+
+
 
     </ul>
   </div>


### PR DESCRIPTION
Uses a static (for now) directory.json file to show more recent feeds on the status page. 
This was created by traversing the openactive data catalogs at https://openactive.io/data-catalogs/data-catalog-collection.jsonld.  